### PR TITLE
feat: Enhance check-release job conditions in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,11 @@ jobs:
   check-release:
     runs-on: ubuntu-latest
     needs: conventional-commits
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+    if: |
+      github.event_name == 'push' && 
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') &&
+      !contains(github.event.head_commit.message, '[skip ci]') &&
+      !contains(github.event.head_commit.message, '[ci skip]')
     permissions:
       contents: write
     outputs:
@@ -200,7 +204,8 @@ jobs:
     if: |
       github.event_name == 'push' && 
       (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') &&
-      needs.check-release.outputs.should_release == 'true'
+      needs.check-release.outputs.should_release == 'true' &&
+      needs.check-release.result == 'success'
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
Updated conditions for the check-release job to skip CI based on commit messages and to ensure the release process only runs on successful checks.