### PR TITLE
feat: Update package-lock.json and package.json with new dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "react-router-dom": "^7.10.1",
-        "react-select": "^5.10.2"
+        "react-select": "^5.10.2",
+        "react-select-async-paginate": "^0.7.11"
       },
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.3",
@@ -2748,6 +2749,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@seznam/compose-react-refs": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@seznam/compose-react-refs/-/compose-react-refs-1.0.6.tgz",
+      "integrity": "sha512-izzOXQfeQLonzrIQb8u6LQ8dk+ymz3WXTIXjvOlTXHq6sbzROg3NWU+9TTAOpEoK9Bth24/6F/XrfHJ5yR5n6Q==",
+      "license": "ISC"
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -3024,6 +3031,15 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vtaits/use-lazy-ref": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@vtaits/use-lazy-ref/-/use-lazy-ref-0.1.4.tgz",
+      "integrity": "sha512-pdHe8k2WLIm8ccVfNw3HzeTCkifKKjVQ3hpiM7/rMynCp8nev715wrY2RCYnbeowNvekWqpGdHtrWKfCDocC6g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -6967,6 +6983,12 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/krustykrab": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/krustykrab/-/krustykrab-1.1.0.tgz",
+      "integrity": "sha512-xpX9MPbw+nJseewe6who9Oq46RQwrBfps+dO/N4fSjJhsf2+y4XWC2kz46oBGX8yzMHyYJj35ug0X5s5yxB6tA==",
+      "license": "MIT"
     },
     "node_modules/lazy-val": {
       "version": "1.0.5",
@@ -11363,6 +11385,24 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/react-select-async-paginate": {
+      "version": "0.7.11",
+      "resolved": "https://registry.npmjs.org/react-select-async-paginate/-/react-select-async-paginate-0.7.11.tgz",
+      "integrity": "sha512-AjtCLPMk5DLNgygwQprEPC0gfVIjkou+QYvXM+2gm/LeRpY1Gv5KNT79EYB37H1uMCrwA+HL9BY7OtlaNWtYNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@seznam/compose-react-refs": "^1.0.6",
+        "@vtaits/use-lazy-ref": "^0.1.4",
+        "krustykrab": "^1.1.0",
+        "sleep-promise": "^9.1.0",
+        "use-is-mounted-ref": "^1.5.0",
+        "use-latest": "^1.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-select": "^5.0.0"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -12402,6 +12442,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/sleep-promise": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/sleep-promise/-/sleep-promise-9.1.0.tgz",
+      "integrity": "sha512-UHYzVpz9Xn8b+jikYSD6bqvf754xL2uBUzDFwiU6NcdZeifPr6UfgU43xpkPu67VMS88+TI2PSI7Eohgqf2fKA==",
+      "license": "MIT"
+    },
     "node_modules/slice-ansi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
@@ -13336,11 +13382,37 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/use-is-mounted-ref": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-is-mounted-ref/-/use-is-mounted-ref-1.5.0.tgz",
+      "integrity": "sha512-p5FksHf/ospZUr5KU9ese6u3jp9fzvZ3wuSb50i0y6fdONaHWgmOqQtxR/PUcwi6hnhQDbNxWSg3eTK3N6m+dg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.0.0"
+      }
+    },
     "node_modules/use-isomorphic-layout-effect": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
       "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
       "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-latest": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz",
+      "integrity": "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.1.1"
+      },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -108,6 +108,6 @@
     "react-dom": "^19.2.3",
     "react-router-dom": "^7.10.1",
     "react-select": "^5.10.2",
-    "react-select-async-paginate": "^7.0.0"
+    "react-select-async-paginate": "^0.7.11"
   }
 }


### PR DESCRIPTION
- Added react-select-async-paginate as a dependency with version 0.7.11.
- Included additional dependencies: @seznam/compose-react-refs, @vtaits/use-lazy-ref, krustykrab, sleep-promise, use-is-mounted-ref, and use-latest in package-lock.json.
- Updated package.json to reflect the new version of react-select-async-paginate.